### PR TITLE
fixed?: fromVector failing on NA and columns named "type"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fusion
 Title: Fusion: Objects class definitions for metabolic profiling
-Version: 1.0.5
+Version: 1.0.6
 Authors@R: 
     person(given = "Julien",
            family = "Wist",

--- a/R/NMRClassDefinitions.R
+++ b/R/NMRClassDefinitions.R
@@ -524,9 +524,11 @@ setGeneric("fromVector", function(input) standardGeneric("fromVector"))
 #'
 setMethod("fromVector", signature(input="ANY"),
           function(input) {
+            if (is.null(input)) return(NA)
             listNames <- names(input)
             if (is.null(listNames)) {
               if (length(input)==1 && any(c("boolean", "character", "logical", "numeric") %in%  is(input))) {
+                if (input == "NA") return(NA)
                 return(input)
               } else {
                 tmp <- lapply(input, function(row) {fromVector(row)})
@@ -537,15 +539,21 @@ setMethod("fromVector", signature(input="ANY"),
                 }
               }
             }else if ("type" %in% listNames) {
-              output <- new(input[["type"]]);
-              slotNames <- names(getSlots(is(output)))
-              #if (all(!is.na(slotNames))) {
+              output <- tryCatch(new(input[["type"]])
+                                 ,error=function(e){
+                                   lapply(input, function(row) fromVector(row))
+                                   }
+                                 )
+              if(is.object(output)){
+                slotNames <- names(getSlots(is(output)))
+                #if (all(!is.na(slotNames))) {
                 for (slotName in slotNames) {
                   if (slotName %in% listNames) {
                     slot(output, slotName) <- fromVector(input[[slotName]])
                   }
                 }
-              #}
+                #}  
+              }
               return(output)
             } else {
               return(lapply(input, function(row) {fromVector(row)}))

--- a/tests/testthat/test-NMRClassDefinition.R
+++ b/tests/testthat/test-NMRClassDefinition.R
@@ -224,8 +224,31 @@ test_that("Check that toJSONFile file works on character", {
 
 })
 
-test_that("Check that toJSONFile file works on matrix", {
-
+test_that("Check that fromVector works with NA", {
+  ppm <-1:10
+  ppm2 <- ppm
+  ppm[[3]] <- NA
+  model1 <- new("NMRSignalModel", signalsInput = list(signal1, signal2),
+               from = ppm[[1]],
+               to =  ppm[[10]],
+               ppm = ppm,
+               experimental = ppm2 * 3)
+  fileName <- "/tmp/model2.json"
+  # Hack the writeToJSON
+  file.create(fileName)
+  fileConn<-file(fileName, "wb")
+  toJSONFile(model1, control=c(no_xy=FALSE), con=fileConn)
+  close(fileConn)
+  
+  fileLines <-readLines(fileName, encoding="UTF-8")
+  fileConn<-file(fileName,"wb")
+  write(paste(fileLines, collapse = ""), fileConn, sep = "")
+  close(fileConn)
+  
+  
+  model1_resurrected <- fromVector( jsonlite::fromJSON(fileName, simplifyVector = FALSE))
+  
+  expect_equal(model1, model1_resurrected)
 })
 
 test_that("Check that writeToJSON and fromVector works for a NMRSignalModel", {


### PR DESCRIPTION
1. fromVector checks for field named "type" to launch S4 parsing. But then I wanted to import an export of a list that contained an actual data.frame with a column named type so... I added a "tryCatch"

2. NA's were exported as null's. When exporting back from the json, those null's become nothing and the data.frame structure was lost.